### PR TITLE
Switch icons to align with official discord and deafen action

### DIFF
--- a/actions/Mute.py
+++ b/actions/Mute.py
@@ -56,7 +56,7 @@ class Mute(DiscordCore):
         else:
             self.hide_error()
         self._muted = value["mute"]
-        icon = Icons.MUTE if not self._muted else Icons.UNMUTE
+        icon = Icons.MUTE if self._muted else Icons.UNMUTE
         self.icon_name = Icons(icon)
         self.current_icon = self.get_icon(self.icon_name)
         self.display_icon()


### PR DESCRIPTION
The refactor changed which icon is displayed when using the deafen action.
I assume this is in error, because it doesn't align with discords own display nor the official streamdeck integration in windows.

This PR fixes the issue.