### PR TITLE
fix(deadlock): Removing deadlock scenario

### DIFF
--- a/actions/DiscordCore.py
+++ b/actions/DiscordCore.py
@@ -31,7 +31,6 @@ class DiscordCore(ActionCore):
 
     def on_ready(self):
         super().on_ready()
-        self.plugin_base.setup_backend()
         self.display_icon()
         self.display_color()
 

--- a/backend.py
+++ b/backend.py
@@ -70,12 +70,16 @@ class Backend(BackendBase):
 
     def setup_client(self):
         try:
+            log.debug("new client")
             self.discord_client = AsyncDiscord(
                 self.client_id, self.client_secret)
+            log.debug("connect")
             self.discord_client.connect(self.discord_callback)
             if not self.access_token:
+                log.debug("authorize")
                 self.discord_client.authorize()
             else:
+                log.debug("authenticate")
                 self.discord_client.authenticate(self.access_token)
         except Exception as ex:
             self.frontend.on_auth_callback(False, str(ex))

--- a/main.py
+++ b/main.py
@@ -28,7 +28,6 @@ class PluginTemplate(PluginBase):
         self.lm.set_to_os_default()
         self._settings_manager = PluginSettings(self)
         self.has_plugin_settings = True
-        self._mutex = threading.Lock()
         self._add_icons()
         self._register_actions()
         backend_path = os.path.join(self.PATH, 'backend.py')
@@ -54,6 +53,7 @@ class PluginTemplate(PluginBase):
         )
 
         self.add_css_stylesheet(os.path.join(self.PATH, "style.css"))
+        self.setup_backend()
 
     def _add_icons(self):
         self.add_icon("deafen", self.get_asset_path("deafen.png"))
@@ -130,16 +130,15 @@ class PluginTemplate(PluginBase):
         self.add_action_holder(toggle_ptt)
 
     def setup_backend(self):
-        with self._mutex:
-            if self.backend and self.backend.is_authed():
-                return
-            settings = self.get_settings()
-            client_id = settings.get('client_id', '')
-            client_secret = settings.get('client_secret', '')
-            access_token = settings.get('access_token', '')
-            refresh_token = settings.get('refresh_token', '')
-            threading.Thread(target=self.backend.update_client_credentials, daemon=True, args=[
-                client_id, client_secret, access_token, refresh_token]).start()
+        if self.backend and self.backend.is_authed():
+            return
+        settings = self.get_settings()
+        client_id = settings.get('client_id', '')
+        client_secret = settings.get('client_secret', '')
+        access_token = settings.get('access_token', '')
+        refresh_token = settings.get('refresh_token', '')
+        threading.Thread(target=self.backend.update_client_credentials, daemon=True, args=[
+            client_id, client_secret, access_token, refresh_token]).start()
 
     def save_access_token(self, access_token: str):
         settings = self.get_settings()

--- a/manifest.json
+++ b/manifest.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.4.7",
+  "version": "1.4.8",
   "thumbnail": "store/thumbnail.png",
   "id": "com_imdevinc_StreamControllerDiscordPlugin",
   "name": "Discord",


### PR DESCRIPTION
This mutex was causing a dead lock, preventing actions from performing more than one thing.
Removing the dead lock and also removing the _need_ for the dead lock, where we only loaded
the backend once an action was loaded. Now we initiate the backend as soon as it loads as the
idea was to only load the backend when it was needed, but we're already loading the entire
backend.
