### PR TITLE
feat(icons): swap PTT and deafen icons

### DIFF
--- a/actions/Deafen.py
+++ b/actions/Deafen.py
@@ -56,7 +56,7 @@ class Deafen(DiscordCore):
         else:
             self.hide_error()
         self._deafened = value["deaf"]
-        icon = Icons.DEAFEN if not self._deafened else Icons.UNDEAFEN
+        icon = Icons.DEAFEN if self._deafened else Icons.UNDEAFEN
         self.icon_name = Icons(icon)
         self.current_icon = self.get_icon(self.icon_name)
         self.display_icon()

--- a/actions/TogglePTT.py
+++ b/actions/TogglePTT.py
@@ -60,7 +60,7 @@ class TogglePTT(DiscordCore):
         else:
             self.hide_error()
         self._mode = value["mode"]["type"]
-        icon = Icons.VOICE if self._mode == ActivityMethod.PTT else Icons.PTT
+        icon = Icons.PTT if self._mode == ActivityMethod.PTT else Icons.VOICE
         self.icon_name = Icons(icon)
         self.current_icon = self.get_icon(self.icon_name)
         self.display_icon()


### PR DESCRIPTION
We already fixed the Mute icon showing incorrectly, but forgot to address PTT and
deafen. This resolves those icons appropriately.
