### PR TITLE
fix(callbacks): Validate callbacks exists

### DIFF
--- a/main.py
+++ b/main.py
@@ -159,6 +159,9 @@ class PluginTemplate(PluginBase):
         self.callbacks[key] = callbacks
 
     def handle_callback(self, key: str, data: any):
+        if key not in self.callbacks:
+            log.warning(f"No callbacks registered for key: {key}")
+            return
         for callback in self.callbacks.get(key):
             callback(data)
 

--- a/manifest.json
+++ b/manifest.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.6.0",
+  "version": "1.6.1",
   "thumbnail": "store/thumbnail.png",
   "id": "com_imdevinc_StreamControllerDiscordPlugin",
   "name": "Discord",


### PR DESCRIPTION
With the new logic that validates the socket connection, there is a potential race condition where
the callback isn't registered, which leads to a python error (`nonetype is not iterable`). This
makes sure that the key exists before trying to call it, thus preventing that error.

Fixes #52
