### PR TITLE
feat(action): Allow mute to explicitly (un)mute

### DIFF
--- a/actions/Mute.py
+++ b/actions/Mute.py
@@ -42,9 +42,41 @@ class Mute(DiscordCore):
             )
         )
 
+        self.event_manager.add_event_assigner(
+            EventAssigner(
+                id="enable-mute",
+                ui_label="enable-mute",
+                default_event=None,
+                callback=self._on_mute
+            )
+        )
+
+        self.event_manager.add_event_assigner(
+            EventAssigner(
+                id="disable-mute",
+                ui_label="disable-mute",
+                default_event=None,
+                callback=self._off_mute
+            )
+        )
+
     def _on_toggle(self, _):
         try:
             self.backend.set_mute(not self._muted)
+        except Exception as ex:
+            log.error(ex)
+            self.show_error(3)
+
+    def _on_mute(self, _):
+        try:
+            self.backend.set_mute(True)
+        except Exception as ex:
+            log.error(ex)
+            self.show_error(3)
+
+    def _off_mute(self, _):
+        try:
+            self.backend.set_mute(False)
         except Exception as ex:
             log.error(ex)
             self.show_error(3)

--- a/manifest.json
+++ b/manifest.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.7.0",
+  "version": "1.7.1",
   "thumbnail": "store/thumbnail.png",
   "id": "com_imdevinc_StreamControllerDiscordPlugin",
   "name": "Discord",


### PR DESCRIPTION
I use the Pedal and find that `toggle-mute`  can be unreliable for a hold-to-talk workflow. This PR adds explicit (un)mute actions to enable unmute on keydown and mute on keyup.