### PR TITLE
fix(socket): Properly cleanup Discord IPC socket on disconnect

### DIFF
--- a/backend.py
+++ b/backend.py
@@ -151,5 +151,16 @@ class Backend(BackendBase):
             self.setup_client()
         self.discord_client.get_selected_voice_channel()
 
+    def close(self):
+        """Cleanup method called when backend is shutting down"""
+        log.debug("Closing Discord backend connection")
+        if self.discord_client:
+            try:
+                self.discord_client.disconnect()
+            except Exception as ex:
+                log.error(f"Error disconnecting Discord client: {ex}")
+            self.discord_client = None
+        self._is_authed = False
+
 
 backend = Backend()

--- a/discordrpc/sockets.py
+++ b/discordrpc/sockets.py
@@ -42,8 +42,15 @@ class UnixPipe:
     def disconnect(self):
         if self.socket is None:
             return
-        self.socket.shutdown(socket.SHUT_RDWR)
-        self.socket.close()
+        try:
+            self.socket.shutdown(socket.SHUT_RDWR)
+        except Exception:
+            pass  # Socket might already be disconnected
+        try:
+            self.socket.close()
+        except Exception:
+            pass
+        self.socket = None  # Reset so connect() creates a fresh socket
 
     def send(self, payload, op):
         payload = json.dumps(payload).encode('UTF-8')


### PR DESCRIPTION
## Summary
- Add close() method to backend to disconnect Discord client on shutdown
- Fix sockets.py disconnect() to reset socket to None after closing
- Add try/except around socket shutdown/close for robustness

## Problem
When restarting StreamController without restarting Discord, the following error occurred:
```
failed to connect to socket /run/user/1000/discord-ipc-0, trying next socket.
[Errno 106] Transport endpoint is already connected
```

## Root Cause
The `disconnect()` method in `sockets.py` was closing the socket but not resetting `self.socket = None`. When `connect()` was called again, it tried to reuse the closed socket object instead of creating a fresh one.